### PR TITLE
override programfile via option at docker run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,6 @@ ONBUILD ADD docker/htdocs /usr/local/trusterd/htdocs
 #
 # exec root owner for now
 
-CMD ["/usr/local/trusterd/bin/trusterd", "/usr/local/trusterd/conf/trusterd.conf.rb"]
+WORKDIR /usr/local/trusterd
+ENTRYPOINT ["./bin/trusterd"]
+CMD ["./conf/trusterd.conf.rb"]

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Run with your configration.
 ```
 mkdir localconf
 vi localconf/your_config.rb ## Write your configration.
-$ docker run -d -v `pwd`/localconf:/usr/local/trusterd/localconf local/trusterd ./localconf/your_config.rb
+$ docker run -d -v `pwd`/localconf:/usr/local/trusterd/localconf -p 8080:8080 local/trusterd ./localconf/your_config.rb
 ```
 
 ##### Access

--- a/README.md
+++ b/README.md
@@ -323,9 +323,30 @@ nghttp -v http://127.0.0.1:8080/index.html
 docker build -t local/trusterd .
 ```
 ##### Runing
+You can run trusted directly.
+```
+$ docker run --rm local/trusterd --help
+Usage: ./bin/trusterd [switches] programfile
+  switches:
+  -b           load and execute RiteBinary (mrb) file
+  -c           check syntax only
+  -e 'command' one line of script
+  -v           print version number, then run in verbose mode
+  --verbose    run in verbose mode
+  --version    print the version
+  --copyright  print the copyright
+```
+Run with default configration. ([docker/conf/trusterd.conf.rb](./docker/conf/trusterd.conf.rb))
 ```
 docker run -d -p 8080:8080 local/trusterd
 ```
+Run with your configration.
+```
+mkdir localconf
+vi localconf/your_config.rb ## Write your configration.
+$ docker run -d -v `pwd`/localconf:/usr/local/trusterd/localconf local/trusterd ./localconf/your_config.rb
+```
+
 ##### Access
 ```
 nghttp -v http://127.0.0.1:8080/index.html

--- a/docker/conf/trusterd.conf.rb
+++ b/docker/conf/trusterd.conf.rb
@@ -74,7 +74,7 @@ s = HTTP2::Server.new({
   # :connection_record => false,
 
   # runngin user, start server with root and change to run_user
-  # :run_user => "daemon",
+  :run_user => "nobody",
 
   # Tuning RLIMIT_NOFILE, start server with root and must set run_user instead of root
   # :rlimit_nofile => 65535,


### PR DESCRIPTION
Docker runの引数で好きなコンフィグを指定できるようにDokerfileを変更しました。

例えばこんな感じ。

`docker run --rm local/trusterd ./conf/user_config.rb`

引数省略時は従来通りの`./conf/trusterd.conf.rb`が使われます。

引数取れると他にも次のようなdocker run ができてうれしい。

```
$ docker run --rm local/trusterd --help
Usage: ./bin/trusterd [switches] programfile
  switches:
  -b           load and execute RiteBinary (mrb) file
  -c           check syntax only
  -e 'command' one line of script
  -v           print version number, then run in verbose mode
  --verbose    run in verbose mode
  --version    print the version
  --copyright  print the copyright
```

```
$ docker run --rm local/trusterd -c
Syntax OK
```
